### PR TITLE
Gn session display fixed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -96,7 +96,6 @@ const instantiateNewApp = (app) => {
   applicationList[app] = {
     name: app,
     timeCount: interval,
-    // rating will be set by user
     rating: 'green',
     howManyTimesHit: 1,
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ const mb = menubar({
 
 let activeSession = false
 let currentSessionName
-let interval = 1000
+const interval = 1000
 let applicationList
 
 mb.on('ready', () => {

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,5 @@
 const electron = require('electron')
+const { dialog } = electron
 const realSessions = require('./real-session-data')
 const sessionsArray = realSessions.realSessions
 
@@ -119,4 +120,5 @@ Object.assign(exports, {
   toggleActiveSession,
   applicationList,
   setSessionNameByUser,
+  dialog,
 })

--- a/lib/render.js
+++ b/lib/render.js
@@ -18,9 +18,9 @@ let storedSessions
 let name
 let sessions = {}
 
-// $('#load-storage-button').on('click', () => {
-//   getSessionsFromStorage()
-// })
+$('#load-storage-button').on('click', () => {
+  getSessionsFromStorage()
+})
 
 const displayStoredSessionsOnPage = (sessions) => {
   $('#session-list-display').html('')
@@ -43,7 +43,7 @@ const getSessionsFromStorage = () => {
   sessions = storedSessions
 }
 
-getSessionsFromStorage()
+// getSessionsFromStorage()
 
 $('#clear-storage-button').on('click', () => {
   clearLocalStorage()
@@ -60,7 +60,7 @@ $('#session-list-display').on('click', '#session-name', (e) => {
 
 const clearLocalStorage = () => {
   localStorage.removeItem('allSessions')
-  getSessionsFromStorage()
+  // getSessionsFromStorage()
 }
 
 $('#session-name-input').on('change', () => {
@@ -69,6 +69,11 @@ $('#session-name-input').on('change', () => {
 })
 
 playButton.on('click', () => {
+  console.log(name)
+  if (!name) {
+    console.log('Oops, no name')
+    return
+  }
   mainProcess.startSession()
 })
 
@@ -78,7 +83,8 @@ pauseButton.on('click', () => {
 
 stopButton.on('click', () => {
   mainProcess.terminateSession(name)
-  getSessionsFromStorage()
+  name = ''
+  // getSessionsFromStorage()
 })
 
 ipc.on('update-session-real-time', (event, data) => {

--- a/lib/render.js
+++ b/lib/render.js
@@ -1,6 +1,7 @@
 const electron = require('electron')
 const { remote } = electron
 const mainProcess = remote.require('./main')
+const { dialog } = mainProcess
 const ipc = electron.ipcRenderer
 const mockSession = require('./mock-session-data')
 const moment = require('moment')
@@ -69,9 +70,10 @@ $('#session-name-input').on('change', () => {
 })
 
 playButton.on('click', () => {
-  console.log(name)
   if (!name) {
-    console.log('Oops, no name')
+    dialog.showMessageBox({
+      message: 'You must enter a unique name for each session.',
+    })
     return
   }
   mainProcess.startSession()

--- a/lib/render.js
+++ b/lib/render.js
@@ -15,21 +15,12 @@ const submitSessionData = $('#submit-session-data')
 
 let mostRecentSession
 let storedSessions
-let chosenSessions = []
 let name
+let sessions = {}
 
-$('#load-storage-button').on('click', () => {
-  getSessionsFromStorage()
-})
-
-$('#clear-storage-button').on('click', () => {
-  clearLocalStorage()
-})
-
-const getSessionsFromStorage = () => {
-  storedSessions = JSON.parse(localStorage.getItem('allSessions'))
-  displayStoredSessionsOnPage(storedSessions)
-}
+// $('#load-storage-button').on('click', () => {
+//   getSessionsFromStorage()
+// })
 
 const displayStoredSessionsOnPage = (sessions) => {
   $('#session-list-display').html('')
@@ -46,18 +37,24 @@ const displayStoredSessionsOnPage = (sessions) => {
   }
 }
 
-// const showClickedSession = (sessionName) => {
-//   console.log('sessionName', sessionName)
-//   // $('#productivity-chart').html('')
-//   // $('#productivity-chart').html(renderSessionTable(session))
-// }
+const getSessionsFromStorage = () => {
+  storedSessions = JSON.parse(localStorage.getItem('allSessions'))
+  displayStoredSessionsOnPage(storedSessions)
+  sessions = storedSessions
+}
+
+getSessionsFromStorage()
+
+$('#clear-storage-button').on('click', () => {
+  clearLocalStorage()
+})
 
 $('#session-list-display').on('click', '#session-name', (e) => {
+  console.log('value of sessions in click event', sessions)
   const keyString = e.target.innerText
+  console.log('keyString', keyString)
   const lastId = sessions[keyString].length - 1
   const targetSession = sessions[keyString][lastId]
-  // console.log('target', targetSession)
-  // $('#productivity-chart').html('')
   $('#productivity-chart').html(renderSessionTable(targetSession))
 })
 
@@ -80,6 +77,7 @@ pauseButton.on('click', () => {
 
 stopButton.on('click', () => {
   mainProcess.terminateSession(name)
+  getSessionsFromStorage()
 })
 
 ipc.on('update-session-real-time', (event, data) => {
@@ -110,7 +108,6 @@ $('#table-button').on('click', () => {
   currentView = 'table'
 })
 
-let sessions = {}
 let lsCounter = 0
 
 // TODO change back to 60 for production

--- a/lib/render.js
+++ b/lib/render.js
@@ -46,6 +46,7 @@ const displayStoredSessionsOnPage = (sessions) => {
 }
 
 $('#session-list-display').on('click', '#session-name', () => {
+  console.log(targetSession)
   $('#productivity-chart').html('')
   $('#productivity-chart').html(renderSessionTable(targetSession))
 })
@@ -53,12 +54,6 @@ $('#session-list-display').on('click', '#session-name', () => {
 const clearLocalStorage = () => {
   localStorage.removeItem('allSessions')
 }
-
-// submitSessionData.on('click', () => {
-//   const name = sessionNameInput.val()
-//   mainProcess.setSessionNameByUser(name)
-//   sessionNameInput.val('')
-// })
 
 $('#session-name-input').on('change', () => {
   name = $('#session-name-input').val()
@@ -89,6 +84,7 @@ ipc.on('hide-session-name-input', (event, data) => {
 })
 
 ipc.on('show-session-name-input', (event, data) => {
+  $('#session-name-input').val('')
   if (data.order === 'Show Session Name') {
     $('#session-name-input').show()
   }

--- a/lib/render.js
+++ b/lib/render.js
@@ -60,6 +60,7 @@ $('#session-list-display').on('click', '#session-name', (e) => {
 
 const clearLocalStorage = () => {
   localStorage.removeItem('allSessions')
+  getSessionsFromStorage()
 }
 
 $('#session-name-input').on('change', () => {

--- a/lib/render.js
+++ b/lib/render.js
@@ -15,7 +15,7 @@ const submitSessionData = $('#submit-session-data')
 
 let mostRecentSession
 let storedSessions
-// let targetSession
+let chosenSessions = []
 let name
 
 $('#load-storage-button').on('click', () => {
@@ -34,14 +34,10 @@ const getSessionsFromStorage = () => {
 const displayStoredSessionsOnPage = (sessions) => {
   $('#session-list-display').html('')
   for (var key in sessions) {
-    let keyString = key.toString()
-    let indexOfLastItem = sessions[keyString].length - 1
-    let targetSession = sessions[keyString][indexOfLastItem]
     if (sessions.hasOwnProperty(key)) {
       $('#session-list-display').append(`
         <h3
           id="session-name"
-          onClick="showClickedSession('${targetSession}')"
         >
           ${key}
         </h3>
@@ -50,17 +46,20 @@ const displayStoredSessionsOnPage = (sessions) => {
   }
 }
 
-const showClickedSession = (session) => {
-  console.log('session', session)
-  $('#productivity-chart').html('')
-  $('#productivity-chart').html(renderSessionTable(session))
-}
+// const showClickedSession = (sessionName) => {
+//   console.log('sessionName', sessionName)
+//   // $('#productivity-chart').html('')
+//   // $('#productivity-chart').html(renderSessionTable(session))
+// }
 
-// $('#session-list-display').on('click', '#session-name', () => {
-//   console.log(targetSession)
-//   $('#productivity-chart').html('')
-//   $('#productivity-chart').html(renderSessionTable(targetSession))
-// })
+$('#session-list-display').on('click', '#session-name', (e) => {
+  const keyString = e.target.innerText
+  const lastId = sessions[keyString].length - 1
+  const targetSession = sessions[keyString][lastId]
+  // console.log('target', targetSession)
+  // $('#productivity-chart').html('')
+  $('#productivity-chart').html(renderSessionTable(targetSession))
+})
 
 const clearLocalStorage = () => {
   localStorage.removeItem('allSessions')

--- a/lib/render.js
+++ b/lib/render.js
@@ -51,9 +51,9 @@ $('#clear-storage-button').on('click', () => {
 })
 
 $('#session-list-display').on('click', '#session-name', (e) => {
-  console.log('value of sessions in click event', sessions)
+  // console.log('value of sessions in click event', sessions)
   const keyString = e.target.innerText
-  console.log('keyString', keyString)
+  // console.log('keyString', keyString)
   const lastId = sessions[keyString].length - 1
   const targetSession = sessions[keyString][lastId]
   $('#productivity-chart').html(renderSessionTable(targetSession))

--- a/lib/render.js
+++ b/lib/render.js
@@ -15,7 +15,7 @@ const submitSessionData = $('#submit-session-data')
 
 let mostRecentSession
 let storedSessions
-let targetSession
+// let targetSession
 let name
 
 $('#load-storage-button').on('click', () => {
@@ -36,20 +36,31 @@ const displayStoredSessionsOnPage = (sessions) => {
   for (var key in sessions) {
     let keyString = key.toString()
     let indexOfLastItem = sessions[keyString].length - 1
-    targetSession = sessions[keyString][indexOfLastItem]
+    let targetSession = sessions[keyString][indexOfLastItem]
     if (sessions.hasOwnProperty(key)) {
       $('#session-list-display').append(`
-        <h3 id="session-name">${key}</h3>
+        <h3
+          id="session-name"
+          onClick="showClickedSession('${targetSession}')"
+        >
+          ${key}
+        </h3>
       `)
     }
   }
 }
 
-$('#session-list-display').on('click', '#session-name', () => {
-  console.log(targetSession)
+const showClickedSession = (session) => {
+  console.log('session', session)
   $('#productivity-chart').html('')
-  $('#productivity-chart').html(renderSessionTable(targetSession))
-})
+  $('#productivity-chart').html(renderSessionTable(session))
+}
+
+// $('#session-list-display').on('click', '#session-name', () => {
+//   console.log(targetSession)
+//   $('#productivity-chart').html('')
+//   $('#productivity-chart').html(renderSessionTable(targetSession))
+// })
 
 const clearLocalStorage = () => {
   localStorage.removeItem('allSessions')

--- a/lib/styles/styles.css
+++ b/lib/styles/styles.css
@@ -122,3 +122,7 @@ button:active {
   left: 3px;
   display: flex;
 }
+
+#session-name {
+  margin: 20px auto;
+}


### PR DESCRIPTION
The user can now click on a displayed session in the sidebar and see data for that session. Thanks to @ianlancaster for helping me to debug this! 

We will need to add data validation so that user cannot enter multiple sessions with same name, plus ideally a way to display sessions on load.

Closes #27 

